### PR TITLE
Ajout de la possibilité de scanner la liste d'un autre DTN (DTN+)

### DIFF
--- a/dtn/interface/joueurs/liste_suivi.php
+++ b/dtn/interface/joueurs/liste_suivi.php
@@ -61,7 +61,11 @@ $_SESSION['ListeFicheResume']=$lstJoueur;
   <td height="55" ><div align="center">
     <table width="100%" border="0" cellspacing="1" cellpadding="0" bgcolor="#000000">
       <tr>
-      <td height="20" bgcolor="#000000"><div align="center"><font color="#FFFFFF">Liste des joueurs suivi par <?=$infAdmin["loginAdmin"]?></font></div></td>
+      <td height="20" bgcolor="#000000"><div align="center"><font color="#FFFFFF">Liste des joueurs suivi par <?=$infAdmin["loginAdmin"]?></font>
+      <form method="post" action="../maliste/miseajour.php">
+      <input type="hidden" name="dtn" value= <?=$_GET['dtn']?> />
+      <input type="submit" value="Mettre &agrave; jour la liste sur Hattrick" />
+                </form></div></td>
       </tr>
       <tr>
       <td><div align="center">

--- a/dtn/interface/maliste/miseajour.php
+++ b/dtn/interface/maliste/miseajour.php
@@ -138,8 +138,13 @@ document.body.scrollTop = scrollPos;
 
 <?php
 if (isset($_SESSION['HT'])) {
+    if (isset($_POST["dtn"]) && $_POST["dtn"]!=$_SESSION['sesUser']["idAdmin"]) { // Si un DTN+ veut faire la màj d'un de ses DTNs
+        $idDTN = $_POST["dtn"];
+    } else {
+        $idDTN = $_SESSION['sesUser']["idAdmin"];
+    }
 
-  $listeJoueursDTN=getJoueurByDTN($_SESSION['sesUser']["idAdmin"]);
+  $listeJoueursDTN=getJoueurByDTN($idDTN);
 
   if(!$listeJoueursDTN){
       echo("Erreur lors de l'extraction des joueurs. Contactez un d&eacute;veloppeurs ou les administrateurs de la DTN.");
@@ -154,7 +159,7 @@ if (isset($_SESSION['HT'])) {
 
   // MAJ des joueurs avec chargement des matchs
   unset($resUpdateJoueur);
-  $resUpdateJoueur=scanListeJoueurs($listeID,$_SESSION['sesUser']["loginAdmin"],"D",true,true);
+  $resUpdateJoueur=scanListeJoueurs($listeID,$idDTN,"D",true,true);
   ?>
   
 


### PR DESCRIPTION
Selon issue #21.

La mise à jour se fait via la page de la liste des joueurs d'un DTN.

Testé en local.