### PR TITLE
suppression drapeaux obsolètes dans page accueil

### DIFF
--- a/menu_haut_de.php
+++ b/menu_haut_de.php
@@ -90,19 +90,21 @@
   <table border="0" cellpadding="0" cellspacing="0">
   <tr><td width="30" height="40"><img src="img/lang_01_border.gif" width="30" height="40" /></td></tr>
   <tr><td width="30" height="25"><a href="setlang.php?language=en<?=$redir?>"><img src="img/lang_02_us.gif" alt="en" title="en" width="30" height="25" border="0" /></a></td></tr>
+  <tr><td width="30" height="6"><img src="img/lang_06_spacer.gif" width="30" height="6" /></td></tr>
   <!-- <tr><td width="30" height="25"><a href="setlang.php?language=es<?=$redir?>"><img src="img/lang_03_sp.gif" alt="es" title="es" width="30" height="25" border="0" /></a></td></tr> -->
-  <tr><td width="30" height="25"><img src="img/lang_03_sp_gr.gif" alt="es" title="es" width="30" height="25" border="0" /></td></tr>
+  <!-- <tr><td width="30" height="25"><img src="img/lang_03_sp_gr.gif" alt="es" title="es" width="30" height="25" border="0" /></td></tr>-->
   <tr><td width="30" height="25"><a href="setlang.php?language=fr<?=$redir?>"><img src="img/lang_04_fr.gif" alt="fr" title="fr" width="30" height="25" border="0" /></a></td></tr>
   <tr><td width="30" height="6"><img src="img/lang_06_spacer.gif" width="30" height="6" /></td></tr>
   <!-- <tr><td width="30" height="25"><a href="setlang.php?language=sv<?=$redir?>"><img src="img/lang_05_sw.gif" alt="sv" title="sv" width="30" height="25" border="0" /></a></td></tr> -->
-  <tr><td width="30" height="25"><img src="img/lang_05_sw_gr.gif" alt="sv" title="sv" width="30" height="25" border="0" /></td></tr>
+  <!-- <tr><td width="30" height="25"><img src="img/lang_05_sw_gr.gif" alt="sv" title="sv" width="30" height="25" border="0" /></td></tr>-->
   <!-- <tr><td width="30" height="25"><a href="setlang.php?language=de<?=$redir?>"><img src="img/lang_07_ge.gif" alt="de" title="de" width="30" height="25" border="0" /></a></td></tr> -->
   <tr><td width="30" height="25"><a href="setlang.php?language=de<?=$redir?>"><img src="img/lang_07_ge.gif" alt="de" title="de" width="30" height="25" border="0" /></a></td>
   </tr>
+  <tr><td width="30" height="6"><img src="img/lang_06_spacer.gif" width="30" height="6" /></td></tr>
   <!-- <tr><td width="30" height="25"><a href="setlang.php?language=zh<?=$redir?>"><img src="img/lang_08_ch.gif" alt="zh" title="zh" width="30" height="25" border="0" /></a></td></tr> -->
-  <tr><td width="30" height="25"><img src="img/lang_08_ch_gr.gif" alt="zh" title="zh" width="30" height="25" border="0" /></td></tr>
+  <!-- <tr><td width="30" height="25"><img src="img/lang_08_ch_gr.gif" alt="zh" title="zh" width="30" height="25" border="0" /></td></tr>-->
   <!-- <tr><td width="30" height="25"><a href="setlang.php?language=pt<?=$redir?>"><img src="img/lang_09_br.gif" alt="pt" title="pt" width="30" height="25" border="0" /></a></td></tr> -->
-  <tr><td width="30" height="25"><img src="img/lang_09_br_gr.gif" alt="pt" title="pt" width="30" height="25" border="0" /></td></tr>
+  <!-- <tr><td width="30" height="25"><img src="img/lang_09_br_gr.gif" alt="pt" title="pt" width="30" height="25" border="0" /></td></tr>-->
   <tr><td width="30" height="224"><img src="img/lang_10_version.gif" width="30" height="224" /></td></tr>
   </table>
   </td>

--- a/menu_haut_en.php
+++ b/menu_haut_en.php
@@ -88,19 +88,21 @@
   <table border="0" cellpadding="0" cellspacing="0">
   <tr><td width="30" height="40"><img src="img/lang_01_border.gif" width="30" height="40" /></td></tr>
   <tr><td width="30" height="25"><a href="setlang.php?language=en<?=$redir?>"><img src="img/lang_02_us.gif" alt="en" title="en" width="30" height="25" border="0" /></a></td></tr>
+  <tr><td width="30" height="6"><img src="img/lang_06_spacer.gif" width="30" height="6" /></td></tr>
   <!-- <tr><td width="30" height="25"><a href="setlang.php?language=es<?=$redir?>"><img src="img/lang_03_sp.gif" alt="es" title="es" width="30" height="25" border="0" /></a></td></tr> -->
-  <tr><td width="30" height="25"><img src="img/lang_03_sp_gr.gif" alt="es" title="es" width="30" height="25" border="0" /></td></tr>
+  <!-- <tr><td width="30" height="25"><img src="img/lang_03_sp_gr.gif" alt="es" title="es" width="30" height="25" border="0" /></td></tr>-->
   <tr><td width="30" height="25"><a href="setlang.php?language=fr<?=$redir?>"><img src="img/lang_04_fr.gif" alt="fr" title="fr" width="30" height="25" border="0" /></a></td></tr>
   <tr><td width="30" height="6"><img src="img/lang_06_spacer.gif" width="30" height="6" /></td></tr>
   <!-- <tr><td width="30" height="25"><a href="setlang.php?language=sv<?=$redir?>"><img src="img/lang_05_sw.gif" alt="sv" title="sv" width="30" height="25" border="0" /></a></td></tr> -->
-  <tr><td width="30" height="25"><img src="img/lang_05_sw_gr.gif" alt="sv" title="sv" width="30" height="25" border="0" /></td></tr>
+  <!-- <tr><td width="30" height="25"><img src="img/lang_05_sw_gr.gif" alt="sv" title="sv" width="30" height="25" border="0" /></td></tr>-->
   <!-- <tr><td width="30" height="25"><a href="setlang.php?language=de<?=$redir?>"><img src="img/lang_07_ge.gif" alt="de" title="de" width="30" height="25" border="0" /></a></td></tr> -->
   <tr><td width="30" height="25"><a href="setlang.php?language=de<?=$redir?>"><img src="img/lang_07_ge.gif" alt="de" title="de" width="30" height="25" border="0" /></a></td>
   </tr>
+  <tr><td width="30" height="6"><img src="img/lang_06_spacer.gif" width="30" height="6" /></td></tr>
   <!-- <tr><td width="30" height="25"><a href="setlang.php?language=zh<?=$redir?>"><img src="img/lang_08_ch.gif" alt="zh" title="zh" width="30" height="25" border="0" /></a></td></tr> -->
-  <tr><td width="30" height="25"><img src="img/lang_08_ch_gr.gif" alt="zh" title="zh" width="30" height="25" border="0" /></td></tr>
+  <!-- <tr><td width="30" height="25"><img src="img/lang_08_ch_gr.gif" alt="zh" title="zh" width="30" height="25" border="0" /></td></tr>-->
   <!-- <tr><td width="30" height="25"><a href="setlang.php?language=pt<?=$redir?>"><img src="img/lang_09_br.gif" alt="pt" title="pt" width="30" height="25" border="0" /></a></td></tr> -->
-  <tr><td width="30" height="25"><img src="img/lang_09_br_gr.gif" alt="pt" title="pt" width="30" height="25" border="0" /></td></tr>
+  <!-- <tr><td width="30" height="25"><img src="img/lang_09_br_gr.gif" alt="pt" title="pt" width="30" height="25" border="0" /></td></tr>-->
   <tr><td width="30" height="224"><img src="img/lang_10_version.gif" width="30" height="224" /></td></tr>
   </table>
   </td>

--- a/menu_haut_fr.php
+++ b/menu_haut_fr.php
@@ -90,19 +90,21 @@
   <table border="0" cellpadding="0" cellspacing="0">
   <tr><td width="30" height="40"><img src="img/lang_01_border.gif" width="30" height="40" /></td></tr>
   <tr><td width="30" height="25"><a href="setlang.php?language=en<?=$redir?>"><img src="img/lang_02_us.gif" alt="en" title="en" width="30" height="25" border="0" /></a></td></tr>
+  <tr><td width="30" height="6"><img src="img/lang_06_spacer.gif" width="30" height="6" /></td></tr>
   <!-- <tr><td width="30" height="25"><a href="setlang.php?language=es<?=$redir?>"><img src="img/lang_03_sp.gif" alt="es" title="es" width="30" height="25" border="0" /></a></td></tr> -->
-  <tr><td width="30" height="25"><img src="img/lang_03_sp_gr.gif" alt="es" title="es" width="30" height="25" border="0" /></td></tr>
+  <!-- <tr><td width="30" height="25"><img src="img/lang_03_sp_gr.gif" alt="es" title="es" width="30" height="25" border="0" /></td></tr>-->
   <tr><td width="30" height="25"><a href="setlang.php?language=fr<?=$redir?>"><img src="img/lang_04_fr.gif" alt="fr" title="fr" width="30" height="25" border="0" /></a></td></tr>
   <tr><td width="30" height="6"><img src="img/lang_06_spacer.gif" width="30" height="6" /></td></tr>
   <!-- <tr><td width="30" height="25"><a href="setlang.php?language=sv<?=$redir?>"><img src="img/lang_05_sw.gif" alt="sv" title="sv" width="30" height="25" border="0" /></a></td></tr> -->
-  <tr><td width="30" height="25"><img src="img/lang_05_sw_gr.gif" alt="sv" title="sv" width="30" height="25" border="0" /></td></tr>
+  <!-- <tr><td width="30" height="25"><img src="img/lang_05_sw_gr.gif" alt="sv" title="sv" width="30" height="25" border="0" /></td></tr>-->
   <!-- <tr><td width="30" height="25"><a href="setlang.php?language=de<?=$redir?>"><img src="img/lang_07_ge.gif" alt="de" title="de" width="30" height="25" border="0" /></a></td></tr> -->
   <tr><td width="30" height="25"><a href="setlang.php?language=de<?=$redir?>"><img src="img/lang_07_ge.gif" alt="de" title="de" width="30" height="25" border="0" /></a></td>
   </tr>
+  <tr><td width="30" height="6"><img src="img/lang_06_spacer.gif" width="30" height="6" /></td></tr>
   <!-- <tr><td width="30" height="25"><a href="setlang.php?language=zh<?=$redir?>"><img src="img/lang_08_ch.gif" alt="zh" title="zh" width="30" height="25" border="0" /></a></td></tr> -->
-  <tr><td width="30" height="25"><img src="img/lang_08_ch_gr.gif" alt="zh" title="zh" width="30" height="25" border="0" /></td></tr>
+  <!-- <tr><td width="30" height="25"><img src="img/lang_08_ch_gr.gif" alt="zh" title="zh" width="30" height="25" border="0" /></td></tr>-->
   <!-- <tr><td width="30" height="25"><a href="setlang.php?language=pt<?=$redir?>"><img src="img/lang_09_br.gif" alt="pt" title="pt" width="30" height="25" border="0" /></a></td></tr> -->
-  <tr><td width="30" height="25"><img src="img/lang_09_br_gr.gif" alt="pt" title="pt" width="30" height="25" border="0" /></td></tr>
+  <!-- <tr><td width="30" height="25"><img src="img/lang_09_br_gr.gif" alt="pt" title="pt" width="30" height="25" border="0" /></td></tr>-->
   <tr><td width="30" height="224"><img src="img/lang_10_version.gif" width="30" height="224" /></td></tr>
   </table>
   </td>


### PR DESCRIPTION
Modification du menu latéral de la page d'accueil https://www.ht-dtnfff.fr/ pour supprimer les drapeaux obsolètes / grisés.
Testé en local, ok. 