### PR TITLE
Ajout recherche secteur TdL et sans secteurs

### DIFF
--- a/dtn/interface/consulter/rechercheJoueur.php
+++ b/dtn/interface/consulter/rechercheJoueur.php
@@ -81,6 +81,8 @@ $lstPos = listAllPosition();
 								<OPTION VALUE="4">Milieu de terrain</OPTION>
 								<OPTION VALUE="3">Ailier</OPTION>
 								<OPTION VALUE="5">Attaquant</OPTION>
+								<OPTION VALUE="6 ">Sans secteur</OPTION>
+								<OPTION VALUE="7 ">Tirs de loin</OPTION>
 						</SELECT>
 						</TD>
 					  </TR>


### PR DESCRIPTION
Ajout de possibilité de chercher des joueurs sans secteur ou TdL dans la page Recherche.
Testé en local.
Répond à issue #60 