### PR TITLE
suppression boutons +1 pour les simples DTN

### DIFF
--- a/dtn/interface/joueurs/ficheDTN.php
+++ b/dtn/interface/joueurs/ficheDTN.php
@@ -321,9 +321,10 @@ if(isset($msg)) {?>
                 <td>&nbsp;<?='['.$res["numCarac"].'] '.$res["intituleCaracFR"]?> <?=$nbSemaineE?></td>
                 <td>
                   <?php if (isset($nomColCarac)) {?>
-                    <a href="javascript:majNiveau('<?=$nomColCarac?>','<?=$joueurDTN[$nomColCarac]?>','<?=$joueurDTN[$nomColCarac]+1?>','<?=$id?>')" class="Vert">+ 1</a><?php
+                    <?php
                     if($sesUser["idNiveauAcces"] == 1 || ( $sesUser["idNiveauAcces"] == 2 && $sesUser["idPosition_fk"] == $joueurDTN["ht_posteAssigne"])){?>
                       &nbsp;|&nbsp;
+                      <a href="javascript:majNiveau('<?=$nomColCarac?>','<?=$joueurDTN[$nomColCarac]?>','<?=$joueurDTN[$nomColCarac]+1?>','<?=$id?>')" class="Vert">+ 1</a>
                       <a href="javascript:majNiveau2('<?=$nomColCarac?>','<?=$joueurDTN[$nomColCarac]?>','<?=$joueurDTN[$nomColCarac]-1?>','<?=$id?>')" class="Rouge">- 1</a>
   		              <?php }
                   }?>


### PR DESCRIPTION
Testé en local avec le compte d'un DTN.
Portait à confusion car les DTN ajoutent parfois des niveaux au lieu de semaines, et ne peuvent revenir en arrière (car ils n'ont pas de boutons -1, réservés aux DTN+/admin)

Désormais les boutons +1/-1 sur les carac sont réservés aux DTN+ et admins