### PR TITLE
Ajout fonction de liste pour assigner joueur sans secteur à son secteur

### DIFF
--- a/dtn/interface/form.php
+++ b/dtn/interface/form.php
@@ -340,6 +340,26 @@ case "assigneJoueur";
 
 	break;
 
+case "assigne1Joueur";
+
+		$sql2 = "select * from $tbl_position where idPosition = $idPosition";
+		$req2 = $conn->query($sql2);
+		$res2 = $req2->fetch(PDO::FETCH_ASSOC);
+
+		$_POST["idJoueur_fk"] = $assigne;
+		$_POST["idAdmin_fk"] = $sesUser["idAdmin"];
+		$_POST["dateHisto"] = date("Y-m-d");
+		$_POST["heureHisto"] = date("H:i");
+		$_POST["intituleHisto"]  = "Assignation du joueur au poste ".$res2["intitulePosition"];
+
+//$sql3 = insertDB($tbl_histomodif);
+
+		$sql = "update $tbl_joueurs set ht_posteAssigne = $idPosition where idJoueur = $assigne";
+		$req = $conn->exec($sql);
+
+	header("location: joueurs/fiche.php?htid=$htid");
+
+	break;
 
 case "assigneJoueurSelection";
 

--- a/dtn/interface/joueurs/fiche.php
+++ b/dtn/interface/joueurs/fiche.php
@@ -29,6 +29,13 @@ if (isset($htid))
   $joueurDTN = getJoueur($id);
 }
 
+// Variable pour fonction affectation joueur sans secteur dans un secteur
+$lstPosition = listPosition();
+if(!isset($affPosition)) $affPosition = 0;
+if (!is_numeric($affPosition))
+	$affPosition = substr($affPosition, 0, 1);
+
+
 // Variable pour menuJoueur.php
 $idHT = $joueurDTN["idHattrickJoueur"];
 $idClubHT=$joueurDTN["teamid"];
@@ -298,9 +305,30 @@ if ($datemaj >$mkday -$huit){
               // ####################### Si Joueur Non suivi et archivé ####################### 
               else if($joueurDTN["archiveJoueur"] == 1){
                  ?><font color="#FF0000"><strong>Ce joueur est archiv&eacute;&nbsp;</strong></font><?php
-                 
+
+              // ####################### Si Joueur Non suivi et non archivé, mais sans secteur ####################### 
+              }else if($joueurDTN["ht_posteAssigne"] == 0){
+				?><font color="#FF0000"><strong>Ce joueur n'est pas suivi ! &nbsp; </strong></font><?php
+				if(($_SESSION['sesUser']["idNiveauAcces"]==2 && ($_SESSION['sesUser']["idPosition_fk"]==$joueurDTN["ht_posteAssigne"]  ||  $_SESSION['sesUser']["idPosition_fk"] == 0) ) ||  $_SESSION['sesUser']["idNiveauAcces"] == 1)
+                {
+				    ?><form name="form0" method="post" action="../form.php"><div align="right">
+					<input name="mode" type="hidden" id="mode" value="assigne1Joueur">
+					<input name="ordre" type="hidden" id="mode" value="<?=$ordre?>">
+					<input name="sens" type="hidden" id="mode" value="<?=$sens?>">
+					<input name="masque" type="hidden" id="mode" value="<?=$masque?>">
+                    <select name="idPosition" id="idPosition">
+                    <?php
+					if($affPosition == $lstPosition["idPosition"]) $etat = "selected"; else $etat = "";
+					echo "<option value = ".$lstPosition["idPosition"]." $etat >".$lstPosition["intitulePosition"]."</option>";
+                    }
+                    ?>
+                    </select>
+					<input type="submit" name="Submit" value="Assigner">
+                    </div></form><?php
+				}
+			
               // ####################### Si Joueur Non suivi et non archivé #######################
-              }else {
+               else {
                 ?><font color="#FF0000"><strong>Ce joueur n'est pas suivi ! &nbsp; </strong></font><?php
                 if(($_SESSION['sesUser']["idNiveauAcces"]==2 && ($_SESSION['sesUser']["idPosition_fk"]==$joueurDTN["ht_posteAssigne"]  ||  $_SESSION['sesUser']["idPosition_fk"] == 0) ) ||  $_SESSION['sesUser']["idNiveauAcces"] == 1)
                 {

--- a/dtn/interface/joueurs/fiche.php
+++ b/dtn/interface/joueurs/fiche.php
@@ -159,6 +159,7 @@ function submitSupprimeSecteur()
   }
   else {
 	  if (confirm('Voulez vous VRAIMENT retirer ce joueur de son Secteur de jeu ?')){
+      document.formSupprimeSecteur.submit();
   }
   }
 }


### PR DESCRIPTION
Dans la fiche d'un joueur sans secteur, à la place de la boîte qui permet d'affecter un joueur à des DTN qui n'existent plus (Bramy, pilec...), reprise de la fonction de liste.php pour affecter le joueur à son secteur (ou au secteur défini par l'admin, avec menu déroulant).
A débugguer et tester en local.