### PR TITLE
Correction de l'affichage des menus de la fiche d'un joueur d'un autre secteur pour tous les onglets

### DIFF
--- a/dtn/interface/menu/menuJoueur.php
+++ b/dtn/interface/menu/menuJoueur.php
@@ -2,6 +2,8 @@
 if(isset($idHT)) {
 
 global $infJ;
+  $joueurDTN = getJoueurHt($htid);
+
 
 /***********************************************
 * Type de menus :


### PR DESCRIPTION
Correction de la page menujoueur afin de définir une variable $joueurDTN valable pour ce menu.

Pour info, les pages sont codées assez salement : dans fiche.php, c'est une variable $joueurDTN qui est utilisée, alors que pour ficheRésumé, ficheForum, etc... c'est une variable $infJ qui est utilisée.

Testé en local, on a maintenant bien le même menu sur toutes les onglets de la page d'un joueur d'un autre secteur.
