### PR TITLE
Ajout des boutons +1 et -1 pour les DTN+ pour les joueurs sans secteurs

### DIFF
--- a/dtn/interface/joueurs/ficheDTN.php
+++ b/dtn/interface/joueurs/ficheDTN.php
@@ -324,10 +324,10 @@ if(isset($msg)) {?>
                 <td>
                   <?php if (isset($nomColCarac)) {?>
                     <?php
-                    if($sesUser["idNiveauAcces"] == 1 || ($sesUser["idNiveauAcces"] == 2 && $sesUser["idPosition_fk"] == $joueurDTN["ht_posteAssigne"]) || ($sesUser["idNiveauAcces"] == 3 && $sesUser["idPosition_fk"] == $joueurDTN["ht_posteAssigne"] && (existAutorisationClub($idClubHT,null)==false))){?>
-                      &nbsp;|&nbsp;
+                    if($sesUser["idNiveauAcces"] == 1 || ($sesUser["idNiveauAcces"] == 2 && $sesUser["idPosition_fk"] == $joueurDTN["ht_posteAssigne"]) || ($sesUser["idNiveauAcces"] == 2 && $joueurDTN["ht_posteAssigne"]==0) || ($sesUser["idNiveauAcces"] == 3 && $sesUser["idPosition_fk"] == $joueurDTN["ht_posteAssigne"] && (existAutorisationClub($idClubHT,null)==false))){?>
                       <a href="javascript:majNiveau('<?=$nomColCarac?>','<?=$joueurDTN[$nomColCarac]?>','<?=$joueurDTN[$nomColCarac]+1?>','<?=$id?>')" class="Vert">+ 1</a>
                       <a href="javascript:majNiveau2('<?=$nomColCarac?>','<?=$joueurDTN[$nomColCarac]?>','<?=$joueurDTN[$nomColCarac]-1?>','<?=$id?>')" class="Rouge">- 1</a>
+                      &nbsp;|&nbsp;
   		              <?php }
                   }?>
                 </td>


### PR DESCRIPTION
Testé en local.
Au passage, j'ai mis le slash "|" de séparation à droite des +1/-1, alors qu'actuellement il était à gauche. Comme cela on comprend mieux que les boutons s'appliquent aux carac et non aux semaines.