### PR TITLE
Correction de l'affichage des onglets pour la fiche d'un joueur d'un autre secteur

### DIFF
--- a/dtn/interface/joueurs/ficheForum.php
+++ b/dtn/interface/joueurs/ficheForum.php
@@ -108,7 +108,7 @@ switch($_SESSION['sesUser']["idNiveauAcces"]){
 }
 
 
-require("../menu/menuJoueur.php");
+require("../menu/menuJoueur_autres_onglets.php");
 
 
 ?>

--- a/dtn/interface/joueurs/fichehattrickchoix.php
+++ b/dtn/interface/joueurs/fichehattrickchoix.php
@@ -582,7 +582,7 @@ $pos=$lstSect[$infJs[1]['ht_posteAssigne']-1]["descriptifPosition"];
 if ($pos=="") $pos="aucun";
 $dtnsuivi="aucun";
 if ($infJs[1]["dtnSuiviJoueur_fk"]!=0) $dtnsuivi=$infJs[1]["loginAdminSuiveur"];    
-if ($origine=="unique") require("../menu/menuJoueur.php");
+if ($origine=="unique") require("../menu/menuJoueur_autres_onglets.php");
 ?>
 <table width="99%" border="1" cellspacing="0" cellpadding="0">
     <tr>

--- a/dtn/interface/joueurs/ficheresumechoix.php
+++ b/dtn/interface/joueurs/ficheresumechoix.php
@@ -612,7 +612,7 @@ $pos=$lstSect[$infJs[1]['ht_posteAssigne']-1]["descriptifPosition"];
 if ($pos=="") $pos="aucun";
 $dtnsuivi="aucun";
 if ($infJs[1]["dtnSuiviJoueur_fk"]!=0) $dtnsuivi=$infJs[1]["loginAdminSuiveur"];    
-if ($origine=="unique") require("../menu/menuJoueur.php");
+if ($origine=="unique") require("../menu/menuJoueur_autres_onglets.php");
 ?>
 <table width="99%" border="1" cellspacing="0" cellpadding="0">
     <tr>

--- a/dtn/interface/joueurs/ficheslackchoix.php
+++ b/dtn/interface/joueurs/ficheslackchoix.php
@@ -580,7 +580,7 @@ $pos=$lstSect[$infJs[1]['ht_posteAssigne']-1]["descriptifPosition"];
 if ($pos=="") $pos="aucun";
 $dtnsuivi="aucun";
 if ($infJs[1]["dtnSuiviJoueur_fk"]!=0) $dtnsuivi=$infJs[1]["loginAdminSuiveur"];    
-if ($origine=="unique") require("../menu/menuJoueur.php");
+if ($origine=="unique") require("../menu/menuJoueur_autres_onglets.php");
 ?>
 <table width="99%" border="1" cellspacing="0" cellpadding="0">
     <tr>

--- a/dtn/interface/joueurs/histoJoueur.php
+++ b/dtn/interface/joueurs/histoJoueur.php
@@ -118,7 +118,7 @@ $id=$idJoueur;
 $idHT=$infJ['idHattrickJoueur'];
 $idClubHT=$infJ['teamid'];
 
-require("../menu/menuJoueur.php");
+require("../menu/menuJoueur_autres_onglets.php");
 
 
 ?>

--- a/dtn/interface/menu/menuJoueur_autres_onglets.php
+++ b/dtn/interface/menu/menuJoueur_autres_onglets.php
@@ -1,0 +1,57 @@
+<?php
+if(isset($idHT)) {
+
+global $infJ;
+
+/***********************************************
+* Type de menus :
+* 1- Menu Complet (Fiche consultation |  Fiche DTN |  Graphiques |  Histo modifs |  Club |  Fiche Forum |  Fiche Résumé  |  Etoiles |  Commentaires / Notes   |  Chercher un joueur )
+* 2- Menu Complet sans "chercher un joueur" ( Fiche consultation |  Fiche DTN |  Graphiques |  Histo modifs |  Club |  Fiche Forum |  Fiche Résumé  |  Etoiles |  Commentaires / Notes)
+* 3- Menu de consultation  ( Fiche consultation |  Fiche Forum |  Fiche Résumé )
+* Menu 1 pour les sélectionneur et les admins        
+* Menu 2 - Si le joueur appartient au secteur du dtn ou dtn+
+*        - Si le joueur n'appartient à aucun secteur
+*        - Si le dtn + a accès à tous les secteurs
+* Menu 3 - Si joueur n'appartient pas au secteur du dtn ou dtn+
+*        - Si le dtn a accès à tous les secteurs             
+***********************************************/
+if (($sesUser["idNiveauAcces"]=="1") or ($sesUser["idNiveauAcces"]=="4")) {$TypeMenu=1;}
+else {
+      if (($sesUser["idPosition_fk"] == $infJ["ht_posteAssigne"]) or ($infJ["ht_posteAssigne"]==0) or ($sesUser["idPosition_fk"]==0 and $sesUser["idNiveauAcces"]=="2") ) {$TypeMenu=2;}
+      else {$TypeMenu=3;}
+}
+//Un DTN ne doit pas pouvoir modifier la fiche de son propre joueur par Musta56 le 28/07/2009 => http://www.ht-fff.org/bug/view.php?id=98
+if ($sesUser["idAdminHT"] == $idClubHT) {$TypeMenu=3;}
+
+
+
+?>
+<table border=0 width=100%>
+<tr><td align="left" nospan>&nbsp;<a href="<?=$url?>/joueurs/fiche.php?htid=<?=$idHT?>" class="smliensorange" alt="consulter">Fiche consultation</a>&nbsp;|
+<?php // On affiche le menu fiche dtn que si le joueur appartient au secteur du dtn ou si c'est le sélectionneur qui est connecté
+if ($TypeMenu <= 2) { ?>
+	&nbsp;<A class="smliensorange" href="<?=$url?>/joueurs/ficheDTN.php?htid=<?=$idHT?>" alt="modifier">Fiche DTN</a>&nbsp;|
+	&nbsp;<A class="smliensorange" href="<?=$url?>/joueurs/graphProgression.php?id=<?=$id?>" alt="graphiques">Graphiques</a>&nbsp;|
+<?php } ?>
+	&nbsp;<A class="smliensorange" href="<?=$url?>/joueurs/histoJoueur.php?htid=<?=$idHT?>" alt="Histos">Histo modifs</a>&nbsp;|
+<?php if ($TypeMenu <= 2) { ?>
+	&nbsp;<A class="smliensorange" href="<?=$url?>/clubs/fiche_club.php?idClubHT=<?=$idClubHT?>" alt="Club">Club</a>&nbsp;|
+<?php } ?>
+	&nbsp;<A class="smliensorange" href="<?=$url?>/joueurs/ficheForum.php?htid=<?=$idHT?>" alt="forum">Fiche Forum</a>&nbsp;|
+	&nbsp;<a class="smliensorange" href="<?=$url?>/joueurs/ficheresumechoix.php?htid=<?=$idHT?>&origine=<?php echo "unique"?>" alt="resume">Fiche R&eacute;sum&eacute;</a>&nbsp;|
+	&nbsp;<a class="smliensorange" href="<?=$url?>/joueurs/ficheslackchoix.php?htid=<?=$idHT?>&origine=<?php echo "unique"?>" alt="resume">Fiche Slack</a>&nbsp;|
+	&nbsp;<a class="smliensorange" href="<?=$url?>/joueurs/fichehattrickchoix.php?htid=<?=$idHT?>&origine=<?php echo "unique"?>" alt="resume">Fiche Hattrick</a>&nbsp;
+    <?php if ($TypeMenu <= 2) { ?>
+  | &nbsp;<A class="smliensorange" href="<?=$url?>/joueurs/rapportDetaille.php?htid=<?=$idHT?>" alt="etoiles">Matchs</a>&nbsp;|
+    &nbsp;<A class="smliensorange" href="<?=$url?>/joueurs/commentaires.php?htid=<?=$idHT?>" alt="commentaires">Commentaires / Notes</a>
+<?php }
+
+if ($TypeMenu <= 1) {  ?>
+
+&nbsp;|
+	&nbsp;<A class="smliensorange" href="<?=$url?>/joueurs/verifPlayer.php" >Chercher un joueur</a>&nbsp;<?php } ?><!-- &nbsp;|
+	&nbsp;<A class="smliensorange" href="<?=$url?>/joueurs/rapportDetailleModif.php?fonction=insert&id=<?=$id?>" class="btn" alt="ajout match">Ajout Match</a>&nbsp;-->
+</td></tr></table>
+<?php
+}
+?>


### PR DESCRIPTION
Affin de résoudre le problème d'affichage : 
- le menuJoueur.php, basé sur la variable $joueurDTN est inchangé, et s'applique aux 2 url associés à fiche.php
- création d'un fichier menuJoueur_autres_onglets.php, basé lui sur la variable $infJ, utilisé pour les ficheForum, hisoModifs, ficheSlack, ficheResume, ficheHattrick (ces fichiers utilisant la variable $inf J).

Avec ces 2 fichiers, plus de problèmes d'affichage des menus des onglets des joueurs d'un autre secteur.
Testé en local.