### PR TITLE
Correction de l'affichage des menus pour l'onglet Commentaires d'un joueur d'un autre secteur

### DIFF
--- a/dtn/interface/joueurs/commentaires.php
+++ b/dtn/interface/joueurs/commentaires.php
@@ -80,7 +80,7 @@ switch($sesUser["idNiveauAcces"]){
 }
 $idHT=$infJ['idHattrickJoueur'];
 $idClubHT=$infJ['teamid'];
-require("../menu/menuJoueur.php");
+require("../menu/menuJoueur_autres_onglets.php");
 ?>
 <script language="JavaScript" src="../includes/javascript/navigation.js"></script>
 <table width="85%"  border="1" align="center" cellpadding="0" cellspacing="0" bordercolor="#000000">


### PR DESCRIPTION
Tout est dans le titre.
Il faut appeler le fichier menuJoueur_autres_onglets au lieu de menuJoueur.
Testé en local.