### PR TITLE
Correction faux message "échec maj club"

### DIFF
--- a/dtn/interface/consulter/rechercheJoueur.php
+++ b/dtn/interface/consulter/rechercheJoueur.php
@@ -607,6 +607,14 @@ jours</TD>
 						<INPUT TYPE="radio" NAME="joueurArchive" VALUE="0" CHECKED>Cacher les joueurs archiv&eacute;s<BR>
 						<INPUT TYPE="radio" NAME="joueurArchive" VALUE="1" >Seulement dans les joueurs archiv&eacute;s<BR>
 					</TR>
+					<TR>
+						<TD COLSPAN="2" VALIGN="top">
+						<BR>
+						<INPUT TYPE="radio" NAME="joueurScanne" VALUE="99" CHECKED>Tous les joueurs (scann&eacute;s et non-scann&eacute;s)<BR>
+						<INPUT TYPE="radio" NAME="joueurScanne" VALUE="1" >Cacher les joueurs non-scann&eacute;s<BR>
+						<INPUT TYPE="radio" NAME="joueurScanne" VALUE="0" >Seulement dans les joueurs non-scann&eacute;s<BR>
+
+					</TR>
           <TR>
 						<TD COLSPAN="2" VALIGN="top">
 						<BR><B>Niveau de l'entraineur :</B><BR>

--- a/dtn/interface/consulter/recherche_result.php
+++ b/dtn/interface/consulter/recherche_result.php
@@ -45,6 +45,7 @@ if(isset($_POST['action']) and $_POST['action'] == 'submitted') {
   $SkillMax4      =$_POST['SkillMax4'];
   $ordreDeTriNb   =$_POST['ordreDeTriNb'];
   $joueurArchive  =$_POST['joueurArchive'];
+  $joueurScanne  =$_POST['joueurScanne'];
   $NivEntraineur  =$_POST['NivEntraineur'];
   $minSalaire     =$_POST['minSalaire'];
   $maxSalaire     =$_POST['maxSalaire'];
@@ -78,6 +79,8 @@ if(isset($_POST['action']) and $_POST['action'] == 'submitted') {
   if(!isset($ordreDeTriNb)) $ordreDeTriNb ="";
   
   if(!isset($joueurArchive)) $joueurArchive =0;
+  
+  if(!isset($joueurScanne)) $joueurScanne =0;
   
 
   if(!isset($NivEntraineur)) $NivEntraineur =0;
@@ -466,6 +469,18 @@ if ($SkillType4!="" && ($SkillMin4!="" || $SkillMax4!="" )){
 				$sql=$sql." AND archiveJoueur=0 ";		
 		
 	}
+	if ($joueurScanne==1){
+		$sql=$sql." AND isScannable=1 ";		
+		?>
+		<li> En montrant uniquement les joueurs scann&eacute;s
+		<?php
+	} elseif ($joueurScanne==0){
+		$sql=$sql." AND isScannable=0 ";		
+		?>
+		<li> En montrant uniquement les joueurs non-scann&eacute;s
+		<?php
+
+	}
 
 	if ($NivEntraineur>=7){
 		$sql=$sql." AND niv_Entraineur=".$NivEntraineur;		
@@ -587,6 +602,7 @@ if(count($lstJ)==0) {
 	       <INPUT TYPE="hidden" NAME="SkillMax4" VALUE="<?=$SkillMax4?>" >
          <INPUT TYPE="hidden" NAME="ordreDeTriNb" VALUE="<?=$ordreDeTriNb?>" >
 	       <INPUT TYPE="hidden" NAME="joueurArchive" VALUE="<?=$joueurArchive?>" >
+	       <INPUT TYPE="hidden" NAME="joueurScanne" VALUE="<?=$joueurScanne?>" >
 	       <INPUT TYPE="hidden" NAME="NivEntraineur" VALUE="<?=$NivEntraineur?>" >
 	       <INPUT TYPE="hidden" NAME="maxSalaire" VALUE="<?=$maxSalaire?>" >
 	       <INPUT TYPE="hidden" NAME="minSalaire" VALUE="<?=$minSalaire?>" >

--- a/dtn/interface/includes/serviceEquipes.php
+++ b/dtn/interface/includes/serviceEquipes.php
@@ -977,8 +977,11 @@ function majClub($idClubHT=null,$idUserHT=null,$clubDTN=null)
 		$resu["logModif"] .= "-id=".$clubDTN["idClubHT"]."-\n";
 		//$clubHT["idClub"]=$clubDTN["idClub"]; //nécessaire à la fonction update qui repère le club sur son idClub et non son idClubHT
 		$resu["idClub"]=insertionClub($clubHT);
+		//ajout pour correction faux message Echec MaJ club
+		$ht_session=existAutorisationClub($idClubHT);
 
-		if ($resu["idClub"]==False)
+		// if ($resu["idClub"]==False)
+		if ($resu["idClub"]==False && $ht_session==false)
 		{
 			//échec de la maj
 			$resu["logModif"] .= "=> Erreur : échec de la MAJ en base\n";


### PR DESCRIPTION
Bug non reproductible en local, donc à tester en prod.
Ajout d'une condition dans servicesEquipes pour tenter de résoudre le problème, à valider en prod.
Cas-test 
- sur le joueur suivant,  442335863 - Alexandre Sorel, on ne doit plus avoir le message sur la fiche du joueur en cliquant sur "Mettre à jour sur Hattrick" car on arrive à récupérer les infos du joueurs (il est scanné)
- sur le joueur suivant, 442868757 - Jean-Baptiste Durand, on doit voir le message en cliquant sur "Mettre à jour sur Hattrick" car le joueur n'est pas scanné.

NB : en local, sur Alexandre Sorel, pas de message Echec MaJ Club :
![image](https://user-images.githubusercontent.com/51236354/62268074-ef6e7680-b42e-11e9-8554-af615a9c8f61.png)

Alors qu'en prod :
![image](https://user-images.githubusercontent.com/51236354/62268304-c26e9380-b42f-11e9-93fe-09ed5657d445.png)