### PR TITLE
Ajout condition pour résolution faux message  "échec MaJ club"

### DIFF
--- a/dtn/interface/includes/serviceEquipes.php
+++ b/dtn/interface/includes/serviceEquipes.php
@@ -977,8 +977,11 @@ function majClub($idClubHT=null,$idUserHT=null,$clubDTN=null)
 		$resu["logModif"] .= "-id=".$clubDTN["idClubHT"]."-\n";
 		//$clubHT["idClub"]=$clubDTN["idClub"]; //nécessaire à la fonction update qui repère le club sur son idClub et non son idClubHT
 		$resu["idClub"]=insertionClub($clubHT);
+		//ajout pour correction faux message Echec MaJ club
+		$ht_session=existAutorisationClub($idClubHT);
 
-		if ($resu["idClub"]==False)
+		// if ($resu["idClub"]==False)
+		if ($resu["idClub"]==False && $ht_session==false)
 		{
 			//échec de la maj
 			$resu["logModif"] .= "=> Erreur : échec de la MAJ en base\n";


### PR DESCRIPTION
Bug non reproductible en local, donc à tester en prod.
Ajout d'une condition dans servicesEquipes pour tenter de résoudre le problème, à valider en prod.
Cas-test 
- sur le joueur suivant,  442335863 - Alexandre Sorel, on ne doit plus avoir le message sur la fiche du joueur en cliquant sur "Mettre à jour sur Hattrick" car on arrive à récupérer les infos du joueurs (il est scanné)
- sur le joueur suivant, 442868757 - Jean-Baptiste Durand, on doit voir le message en cliquant sur "Mettre à jour sur Hattrick" car le joueur n'est pas scanné.

NB : en local, sur Alexandre Sorel, pas de message Echec MaJ Club :
![image](https://user-images.githubusercontent.com/51236354/62268074-ef6e7680-b42e-11e9-8554-af615a9c8f61.png)

Alors qu'en prod :
![image](https://user-images.githubusercontent.com/51236354/62268304-c26e9380-b42f-11e9-93fe-09ed5657d445.png)